### PR TITLE
Update nature.yml

### DIFF
--- a/collections/nature.yml
+++ b/collections/nature.yml
@@ -5,30 +5,30 @@ nfts:
   imageUrl: >-
     https://gateway.ipfs.io/ipfs/bafybeidwjfbik4re6gyautimgnz4hsge5mpgilfzrvh3ymrxmxxgliql4m
 - tokenId: 7f46832b69ac7523344444178d739a958fc53c1dec0ebb4a43e0f954a7cf2402
-  name: 'Nature. Night Forest. Freehand drawing #1/4'
+  name: 'Nature. Night Forest. Freehand drawing #1&#x2F;4'
   description: >-
-    Nature. Night Forest. Freehand drawing #1/4. 1800x2577 px. Author
+    Nature. Night Forest. Freehand drawing #1&#x2F;4. 1800x2577 px. Author
     @maritsaart
   imageUrl: >-
     https://gateway.ipfs.io/ipfs/bafybeicprkwo5mn3tzz3me6ruv24qgtiqonffcxf567lyq4oxsmmsgbycu
 - tokenId: 903043d2f94c72d01e2a8237451f09bba987bbb5b9986ed57bdb432cccada6fb
-  name: 'Nature. Night Forest. Freehand drawing #2/4'
+  name: 'Nature. Night Forest. Freehand drawing #2&#x2F;4'
   description: >-
-    Nature. Night Forest. Freehand drawing #2/4. 1800x2577 px. Author
+    Nature. Night Forest. Freehand drawing #2&#x2F;4. 1800x2577 px. Author
     @maritsaart
   imageUrl: >-
     https://gateway.ipfs.io/ipfs/bafybeifzixnq7f4poumg26ms2cv45mpainnycpyxdqmzyrsg4gjigltf44
 - tokenId: 0fb390493a46449e35e39d54fd414ca564fc9ce1fc15973041c26b7800cc9479
-  name: 'Nature. Night Forest. Freehand drawing #3/4'
+  name: 'Nature. Night Forest. Freehand drawing #3&#x2F;4'
   description: >-
-    Nature. Night Forest. Freehand drawing #3/4. 1800x2577 px. Author
+    Nature. Night Forest. Freehand drawing #3&#x2F;4. 1800x2577 px. Author
     @maritsaart
   imageUrl: >-
     https://gateway.ipfs.io/ipfs/bafybeidpeo77rxpxst2ve63rhzotep2ibx6ym525kjexwyjm5mz2bfu2bq
 - tokenId: ad1297e30be7d92d51c1e93722b6613955116b4f430455417222dbbbbd725981
-  name: 'Nature. Night Forest. Freehand drawing #4/4'
+  name: 'Nature. Night Forest. Freehand drawing #4&#x2F;4'
   description: >-
-    Nature. Night Forest. Freehand drawing #4/4. 1800x2577 px. Author
+    Nature. Night Forest. Freehand drawing #4&#x2F;4. 1800x2577 px. Author
     @maritsaart
   imageUrl: >-
     https://gateway.ipfs.io/ipfs/bafybeidk4xrn2josjnc43m3cf7xxvrsxbmv5eilszaajxve43vqv2lihzi


### PR DESCRIPTION
Prevent automatic conversion of NFT numbers 1/4, 2/4, 3/4, 4/4 ... to single-character Unicode fractions.